### PR TITLE
add case for 'main' branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "git-tag-version",
   "description": "Calculate project version from git tags.",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "homepage": "https://github.com/bushee/git-tag-version",
   "author": {
     "name": "Jerzy Jelinek",

--- a/src/git-tag-version.js
+++ b/src/git-tag-version.js
@@ -75,7 +75,7 @@ module.exports = function (options) {
             var getBranchName = 'git rev-parse --abbrev-ref HEAD',
                 branchNameTrimmed;
             branchNameTrimmed = cp.execSync(getBranchName, {cwd: '.'}).toString().trim().replace(/[^0-9A-Za-z-]/g, '-');
-            if (branchNameTrimmed === 'master') {
+            if (branchNameTrimmed === 'master' || branchNameTrimmed === 'main') {
                 return versionPrefix + getSnapshotSuffix();
             }
             return versionPrefix + '-' + branchNameTrimmed + getSnapshotSuffix();


### PR DESCRIPTION
modern repos have 'main' branch as the default, instead of 'master'. Adding a clause for that case.